### PR TITLE
Re-export chrono

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,9 @@ limitations under the License.
 #[macro_use] extern crate log;
 extern crate env_logger;
 
-extern crate chrono;
-
 use std::collections::{HashMap};
 use bitvec::prelude::*;
+pub use chrono;
 use chrono::{DateTime};
 use chrono::prelude::*;
 


### PR DESCRIPTION
Since there are `chrono` types in the public API, this PR re-exports `chrono` so that it's possible for consumers of `nmea-parser` to name the the `chrono` types (E.g. `DateTime` and `Utc`). This also means consumers don't need to add `chrono` in their own `Cargo.toml` or keep the version synced with `nmea-parser`.