### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ edition       = "2018"
 bitvec     = "0.19.3"
 chrono     = "0.4.19"
 log        = "0.4.11"
-env_logger = "0.8.1"
 assert     = "0.7.4"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition       = "2018"
 
 [dependencies]
 bitvec     = "0.19.3"
-regex      = "1.4.0"
 chrono     = "0.4.19"
 log        = "0.4.11"
 env_logger = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ edition       = "2018"
 bitvec     = "0.19.3"
 chrono     = "0.4.19"
 log        = "0.4.11"
+
+[dev-dependencies]
 assert     = "0.7.4"
 
 [badges]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ limitations under the License.
 #![allow(dead_code)]
 
 #[macro_use] extern crate log;
-extern crate env_logger;
 
 extern crate chrono;
 


### PR DESCRIPTION
This PR:

* Implements lat/lon parsing without a regular expression, allowing the `regex` dependency to be dropped.
* Drops the unused `env_logger` dependency.
* Makes `assert` a `dev-dependency` so that consumers of the crate don't pull it in.