### PR TITLE
Use pub(crate) in favour of doc(hidden)

### DIFF
--- a/src/ais/mod.rs
+++ b/src/ais/mod.rs
@@ -16,28 +16,17 @@ limitations under the License.
 
 //! AIS VDM/VDO data structures
 
-#[doc(hidden)]
-pub mod vdm_t1t2t3;
-#[doc(hidden)]
-pub mod vdm_t4;
-#[doc(hidden)]
-pub mod vdm_t5;
-#[doc(hidden)]
-pub mod vdm_t6;
-#[doc(hidden)]
-pub mod vdm_t9;
-#[doc(hidden)]
-pub mod vdm_t10;
-#[doc(hidden)]
-pub mod vdm_t18;
-#[doc(hidden)]
-pub mod vdm_t19;
-#[doc(hidden)]
-pub mod vdm_t24;
-#[doc(hidden)]
-pub mod vdm_t21;
-#[doc(hidden)]
-pub mod vdm_t27;
+pub(crate) mod vdm_t1t2t3;
+pub(crate) mod vdm_t4;
+pub(crate) mod vdm_t5;
+pub(crate) mod vdm_t6;
+pub(crate) mod vdm_t9;
+pub(crate) mod vdm_t10;
+pub(crate) mod vdm_t18;
+pub(crate) mod vdm_t19;
+pub(crate) mod vdm_t24;
+pub(crate) mod vdm_t21;
+pub(crate) mod vdm_t27;
 
 use super::*;
 pub use vdm_t4::{BaseStationReport};

--- a/src/ais/vdm_t10.rs
+++ b/src/ais/vdm_t10.rs
@@ -37,9 +37,8 @@ pub struct UtcDateInquiry {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 10: UTC/Date Inquiry
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::UtcDateInquiry(UtcDateInquiry{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t18.rs
+++ b/src/ais/vdm_t18.rs
@@ -15,9 +15,8 @@ limitations under the License.
 */
 use super::*;
 
-#[doc(hidden)]
-/// AIS VDM/VDO type 18: Standard Class B CS Position Report 
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+/// AIS VDM/VDO type 18: Standard Class B CS Position Report
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::VesselDynamicData(VesselDynamicData{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t19.rs
+++ b/src/ais/vdm_t19.rs
@@ -15,9 +15,8 @@ limitations under the License.
 */
 use super::*;
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 19: Extended Class B Equipment Position Report
-pub fn handle(_bv: &BitVec, _station: Station, _own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(_bv: &BitVec, _station: Station, _own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     // TODO: implementation (Class B)
     return Err(ParseError::UnsupportedSentenceType("Unsupported AIVDM message type: 19".into()));
 }

--- a/src/ais/vdm_t1t2t3.rs
+++ b/src/ais/vdm_t1t2t3.rs
@@ -16,9 +16,8 @@ limitations under the License.
 
 use super::*;
 
-#[doc(hidden)]
 /// AIS VDM/VDO types 1-3: Position Report with SOTDMA/ITDMA
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::VesselDynamicData(VesselDynamicData{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t21.rs
+++ b/src/ais/vdm_t21.rs
@@ -288,9 +288,8 @@ impl std::fmt::Display for NavAidType {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 21: Aid-to-Navigation Report
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::AidToNavigationReport(AidToNavigationReport{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t24.rs
+++ b/src/ais/vdm_t24.rs
@@ -15,9 +15,8 @@ limitations under the License.
 */
 use super::*;
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 24: Static data report
-pub fn handle(bv: &BitVec, _station: Station, store: &mut NmeaParser, own_vessel: bool) 
+pub(crate) fn handle(bv: &BitVec, _station: Station, store: &mut NmeaParser, own_vessel: bool)
 -> Result<ParsedSentence, ParseError> {
     // Check whether the message bit layout follows part A or part B format
     // We use two complementary booleans to make the code more readable.

--- a/src/ais/vdm_t27.rs
+++ b/src/ais/vdm_t27.rs
@@ -16,9 +16,8 @@ limitations under the License.
 
 use super::*;
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 27: Long Range AIS Broadcast message
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::VesselDynamicData(VesselDynamicData{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t4.rs
+++ b/src/ais/vdm_t4.rs
@@ -68,9 +68,8 @@ impl LatLon for BaseStationReport {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 4: Base Station Report
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::BaseStationReport(BaseStationReport{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t5.rs
+++ b/src/ais/vdm_t5.rs
@@ -15,9 +15,8 @@ limitations under the License.
 */
 use super::*;
 
-#[doc(hidden)]
 /// AIVDM type 5: Ship static voyage related data
-pub fn handle(bv: &BitVec, _station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, _station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::VesselStaticData(VesselStaticData{
         own_vessel:              own_vessel,
         ais_type:                AisClass::ClassB,

--- a/src/ais/vdm_t6.rs
+++ b/src/ais/vdm_t6.rs
@@ -60,10 +60,9 @@ impl LatLon for BinaryAddressedMessage {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 6: Binary Addressed Message. Implementation of the 920-bit data field is
 /// unimplemented currently.
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::BinaryAddressedMessage(BinaryAddressedMessage{
         own_vessel: {
             own_vessel

--- a/src/ais/vdm_t9.rs
+++ b/src/ais/vdm_t9.rs
@@ -83,9 +83,8 @@ impl LatLon for StandardSarAircraftPositionReport {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// AIS VDM/VDO type 9: Standard SAR Aircraft Position Report
-pub fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(bv: &BitVec, station: Station, own_vessel: bool) -> Result<ParsedSentence, ParseError> {
     return Ok(ParsedSentence::StandardSarAircraftPositionReport(StandardSarAircraftPositionReport{
         own_vessel: {
             own_vessel

--- a/src/gnss/gga.rs
+++ b/src/gnss/gga.rs
@@ -113,9 +113,8 @@ impl std::fmt::Display for GgaQualityIndicator {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// xxGGA: Global Positioning System Fix Data
-pub fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
     let now: DateTime<Utc> = Utc::now();
     let split: Vec<&str> = sentence.split(',').collect();
     

--- a/src/gnss/gll.rs
+++ b/src/gnss/gll.rs
@@ -49,9 +49,8 @@ impl LatLon for GllData {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// xxGLL: Geographic Position, Latitude / Longitude and time.
-pub fn handle(sentence: &str, nav_system: NavigationSystem) 
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem)
               -> Result<ParsedSentence, ParseError> {
     let now: DateTime<Utc> = Utc::now();
     let split: Vec<&str> = sentence.split(',').collect();

--- a/src/gnss/gsa.rs
+++ b/src/gnss/gsa.rs
@@ -65,9 +65,8 @@ impl std::fmt::Display for GsaFixMode {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
-/// xxGSA: GPS DOP and active satellites 
-pub fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
+/// xxGSA: GPS DOP and active satellites
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
     let split: Vec<&str> = sentence.split(',').collect();
     
     return Ok(ParsedSentence::Gsa(GsaData{

--- a/src/gnss/gsv.rs
+++ b/src/gnss/gsv.rs
@@ -36,9 +36,8 @@ pub struct GsvData {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// xxGSV: GPS Satellites in view
-pub fn handle(sentence: &str, nav_system: NavigationSystem, store: &mut NmeaParser) 
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem, store: &mut NmeaParser)
               -> Result<ParsedSentence, ParseError> {
     let split: Vec<&str> = sentence.split(',').collect();
 

--- a/src/gnss/mod.rs
+++ b/src/gnss/mod.rs
@@ -16,18 +16,12 @@ limitations under the License.
 
 //! GNSS-related data structures
 
-#[doc(hidden)]
-pub mod gga;
-#[doc(hidden)]
-pub mod gsa;
-#[doc(hidden)]
-pub mod gsv;
-#[doc(hidden)]
-pub mod rmc;
-#[doc(hidden)]
-pub mod vtg;
-#[doc(hidden)]
-pub mod gll;
+pub(crate) mod gga;
+pub(crate) mod gsa;
+pub(crate) mod gsv;
+pub(crate) mod rmc;
+pub(crate) mod vtg;
+pub(crate) mod gll;
 
 use super::*;
 pub use rmc::RmcData;

--- a/src/gnss/rmc.rs
+++ b/src/gnss/rmc.rs
@@ -55,9 +55,8 @@ impl LatLon for RmcData {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// xxRMC: Recommended minimum specific GPS/Transit data
-pub fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem) -> Result<ParsedSentence, ParseError> {
     let split: Vec<&str> = sentence.split(',').collect();
     
     return Ok(ParsedSentence::Rmc(RmcData{

--- a/src/gnss/vtg.rs
+++ b/src/gnss/vtg.rs
@@ -39,9 +39,8 @@ pub struct VtgData {
 
 // -------------------------------------------------------------------------------------------------
 
-#[doc(hidden)]
 /// xxVTG: Track Made Good and Ground Speed
-pub fn handle(sentence: &str, nav_system: NavigationSystem) 
+pub(crate) fn handle(sentence: &str, nav_system: NavigationSystem)
               -> Result<ParsedSentence, ParseError> {
     let split: Vec<&str> = sentence.split(',').collect();
 


### PR DESCRIPTION
This replaces the use of `#[doc(hidden)]` with `pub(crate)`. The documentation remains the same but now the visibility of the functions is actually enforced (I.e. they're not accessible).