### PR TITLE
Added _opt on Utc to catch invalid date and propagate ParseError

### DIFF
--- a/src/ais/vdm_t4.rs
+++ b/src/ais/vdm_t4.rs
@@ -79,18 +79,14 @@ pub(crate) fn handle(
         station: { station },
         mmsi: { pick_u64(&bv, 8, 30) as u32 },
         timestamp: {
-            Some(
-                Utc.ymd(
-                    pick_u64(&bv, 38, 14) as i32,
-                    pick_u64(&bv, 52, 4) as u32,
-                    pick_u64(&bv, 56, 5) as u32,
-                )
-                .and_hms(
-                    pick_u64(&bv, 61, 5) as u32,
-                    pick_u64(&bv, 66, 6) as u32,
-                    pick_u64(&bv, 72, 6) as u32,
-                ),
-            )
+            Some(parse_ymdhs(
+                pick_u64(&bv, 38, 14) as i32,
+                pick_u64(&bv, 52, 4) as u32,
+                pick_u64(&bv, 56, 5) as u32,
+                pick_u64(&bv, 61, 5) as u32,
+                pick_u64(&bv, 66, 6) as u32,
+                pick_u64(&bv, 72, 6) as u32,
+            )?)
         },
         high_position_accuracy: { pick_u64(&bv, 78, 1) != 0 },
         latitude: {

--- a/src/ais/vdm_t5.rs
+++ b/src/ais/vdm_t5.rs
@@ -69,7 +69,7 @@ pub(crate) fn handle(
                 _ => Some(PositionFixType::new(raw)),
             }
         },
-        eta: pick_eta(&bv, 274),
+        eta: pick_eta(&bv, 274)?,
         draught10: Some(pick_u64(&bv, 294, 8) as u8),
         destination: {
             let raw = pick_string(&bv, 302, 20);

--- a/src/ais/vdm_t6.rs
+++ b/src/ais/vdm_t6.rs
@@ -87,7 +87,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_parse_vdm_type5() {
+    fn test_parse_vdm_type6() {
         let mut p = NmeaParser::new();
         match p.parse_sentence("!AIVDM,1,1,,B,6B?n;be:cbapalgc;i6?Ow4,2*4A") {
             Ok(ps) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 //! # NMEA Parser: NMEA parser for Rust
 //!
-//! This crate aims to cover all AIS sentences and the most important GNSS sentences used with 
-//! NMEA 0183 standard. The parser supports AIS class A and B types and identifies GPS, GLONASS, 
+//! This crate aims to cover all AIS sentences and the most important GNSS sentences used with
+//! NMEA 0183 standard. The parser supports AIS class A and B types and identifies GPS, GLONASS,
 //! Galileo, BeiDou, NavIC and QZSS satellite systems.
 
 #![allow(dead_code)]
@@ -41,7 +41,7 @@ use util::*;
 
 // -------------------------------------------------------------------------------------------------
 
-/// Result from function `NmeaParser::parse_sentence()`. If the given sentence represents only a 
+/// Result from function `NmeaParser::parse_sentence()`. If the given sentence represents only a
 /// partial message `ParsedMessage::Incomplete` is returned.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParsedMessage {
@@ -746,6 +746,18 @@ mod test {
             .parse_sentence("!AIVDM,1,1,,A,38Id705000rRVJhE7cl9n;160000,0")
             .ok()
             .is_some());
+    }
+
+    #[test]
+    fn test_parse_invalid_utc() {
+        // Try a sentence with invalite utc
+        let mut p = NmeaParser::new();
+        assert_eq!(
+            p.parse_sentence("!AIVDM,1,1,,B,4028iqT47wP00wGiNbH8H0700`2H,0*13"),
+            Err(ParseError::InvalidSentence(String::from(
+                "Failed to parse Utc Date from y:4161 m:15 d:31 h:0 m:0 s:0"
+            )))
+        );
     }
 
     #[test]


### PR DESCRIPTION
I had an AIS file with this  sentence: !AIVDM,1,1,,B,4028iqT47wP00wGiNbH8H0700`2H,0*13
that panicked the lib. ( Year 4000+ and month 15 ... )
Using Utc _opt methods from chrono allows date validation and proper ParseError propagation.