### PR TITLE
Use parse_ymdhs to return an option and propagate errors instead of p…

### DIFF
--- a/src/ais/vdm_t11.rs
+++ b/src/ais/vdm_t11.rs
@@ -27,18 +27,14 @@ pub(crate) fn handle(
         station: { station },
         mmsi: { pick_u64(&bv, 8, 30) as u32 },
         timestamp: {
-            Some(
-                Utc.ymd(
-                    pick_u64(&bv, 38, 14) as i32,
-                    pick_u64(&bv, 52, 4) as u32,
-                    pick_u64(&bv, 56, 5) as u32,
-                )
-                .and_hms(
-                    pick_u64(&bv, 61, 5) as u32,
-                    pick_u64(&bv, 66, 6) as u32,
-                    pick_u64(&bv, 72, 6) as u32,
-                ),
-            )
+            Some(parse_ymdhs(
+                pick_u64(&bv, 38, 14) as i32,
+                pick_u64(&bv, 52, 4) as u32,
+                pick_u64(&bv, 56, 5) as u32,
+                pick_u64(&bv, 61, 5) as u32,
+                pick_u64(&bv, 66, 6) as u32,
+                pick_u64(&bv, 72, 6) as u32,
+            )?)
         },
         high_position_accuracy: { pick_u64(&bv, 78, 1) != 0 },
         latitude: {


### PR DESCRIPTION
Same as my previous PR.

Use helper: parse_ymdhs
Avoids panicking on invalid dates and propagate parsing errors