### PR TITLE
Fixed panic on proprietary messages

### DIFF
--- a/src/ais/mod.rs
+++ b/src/ais/mod.rs
@@ -96,6 +96,29 @@ impl std::fmt::Display for Station {
     }
 }
 
+impl std::str::FromStr for Station {
+    type Err = ParseError;
+
+    fn from_str(talker_id: &str) -> Result<Self, Self::Err> {
+        if talker_id.len() < 2 {
+            return Err(ParseError::InvalidSentence(
+                "Invalid station identifier".to_string(),
+            ));
+        }
+        match &talker_id[0..2] {
+            "AB" => Ok(Self::BaseStation),
+            "AD" => Ok(Self::DependentAisBaseStation),
+            "AI" => Ok(Self::MobileStation),
+            "AN" => Ok(Self::AidToNavigationStation),
+            "AR" => Ok(Self::AisReceivingStation),
+            "AS" => Ok(Self::LimitedBaseStation),
+            "AT" => Ok(Self::AisTransmittingStation),
+            "AX" => Ok(Self::RepeaterStation),
+            _ => Ok(Self::Other),
+        }
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 
 /// Types 1, 2, 3 and 18: Position Report Class A, and Long Range AIS Broadcast message

--- a/src/gnss/mod.rs
+++ b/src/gnss/mod.rs
@@ -83,6 +83,9 @@ pub enum NavigationSystem {
     // Japanese Qzss
     Qzss, // QZxxx
 
+    /// Proprietary manufacturer specific message
+    Proprietary, // PMMM, P usually followed by a three character manufacturer code
+
     // Some other
     Other,
 }
@@ -97,7 +100,39 @@ impl std::fmt::Display for NavigationSystem {
             NavigationSystem::Beidou => write!(f, "BeiDou"),
             NavigationSystem::Navic => write!(f, "Navic"),
             NavigationSystem::Qzss => write!(f, "QZSS"),
+            NavigationSystem::Proprietary => write!(f, "proprietary"),
             NavigationSystem::Other => write!(f, "other"),
+        }
+    }
+}
+
+impl std::str::FromStr for NavigationSystem {
+    type Err = ParseError;
+
+    fn from_str(talker_id: &str) -> Result<Self, Self::Err> {
+        if talker_id.len() < 1 {
+            return Err(ParseError::InvalidSentence(
+                "Invalid talker identifier".to_string(),
+            ));
+        }
+        if &talker_id[0..1] == "P" {
+            Ok(Self::Proprietary)
+        } else {
+            if talker_id.len() < 2 {
+                return Err(ParseError::InvalidSentence(
+                    "Invalid talker identifier".to_string(),
+                ));
+            }
+            match &talker_id[0..2] {
+                "GN" => Ok(Self::Combination),
+                "GP" => Ok(Self::Gps),
+                "GL" => Ok(Self::Glonass),
+                "GA" => Ok(Self::Galileo),
+                "BD" => Ok(Self::Beidou),
+                "GI" => Ok(Self::Navic),
+                "QZ" => Ok(Self::Qzss),
+                _ => Ok(Self::Other),
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,7 +592,7 @@ mod test {
 
     #[test]
     fn test_parse_proprietary() {
-        // Try a sentence with invalite utc
+        // Try a proprietary sentence
         let mut p = NmeaParser::new();
         assert_eq!(
             p.parse_sentence("$PGRME,15.0,M,45.0,M,25.0,M*1C"),
@@ -600,10 +600,35 @@ mod test {
                 "Unsupported sentence type: $RME"
             )))
         );
+        // Try a proprietary sentence with four characters
         assert_eq!(
             p.parse_sentence("$PGRM,00,1,,,*15"),
             Err(ParseError::UnsupportedSentenceType(String::from(
                 "Unsupported sentence type: $PGRM"
+            )))
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_talker() {
+        // Try parse malformed sentences
+        let mut p = NmeaParser::new();
+        assert_eq!(
+            p.parse_sentence("$QQ,*2C"),
+            Err(ParseError::UnsupportedSentenceType(String::from(
+                "Unsupported sentence type: $QQ"
+            )))
+        );
+        assert_eq!(
+            p.parse_sentence("$A,a0,*10"),
+            Err(ParseError::InvalidSentence(String::from(
+                "Invalid talker identifier"
+            )))
+        );
+        assert_eq!(
+            p.parse_sentence("$,0a,*51"),
+            Err(ParseError::InvalidSentence(String::from(
+                "Invalid talker identifier"
             )))
         );
     }


### PR DESCRIPTION
The parser would panic if the first token in the sentence was of other
length than six. For example proprietary messages.
