### PR TITLE
Feat bump bitvec to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,24 @@
 [package]
-name          = "nmea-parser"
-version       = "0.10.0-dev"
-publish       = false
-description   = "NMEA 0183 parser for AIS and GNSS sentences"
-authors       = ["Timo Saarinen <zaari@mailbox.org>"]
-license       = "Apache-2.0"
-repository    = "https://github.com/zaari/nmea-parser"
+name = "nmea-parser"
+version = "0.10.0-dev"
+publish = false
+description = "NMEA 0183 parser for AIS and GNSS sentences"
+authors = ["Timo Saarinen <zaari@mailbox.org>"]
+license = "Apache-2.0"
+repository = "https://github.com/zaari/nmea-parser"
 documentation = "https://docs.rs/nmea-parser"
-keywords      = ["nmea", "ais", "gnss", "gps", "no_std"]
-categories    = ["parsing"]
-readme        = "README.md"
-edition       = "2018"
+keywords = ["nmea", "ais", "gnss", "gps", "no_std"]
+categories = ["parsing"]
+readme = "README.md"
+edition = "2018"
 #rust-version  = "1.43"
 
 [dependencies]
-bitvec     = { version = "0.22.3", default-features = false, features = ["alloc"] }
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.14", default-features = false }
-chrono     = { version = "0.4.19", default-features = false }
-log        = "0.4.14"
-hashbrown  = "0.11"
+chrono = { version = "0.4.19", default-features = false }
+log = "0.4.14"
+hashbrown = "0.11"
 
 [dev-dependencies]
-assert     = "0.7.4"
-
+assert = "0.7.4"

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,7 +35,7 @@ pub(crate) fn make_fragment_key(
 
 /// Convert AIS VDM/VDO payload armored string into a `BitVec`.
 pub(crate) fn parse_payload(payload: &str) -> Result<BitVec, String> {
-    let mut bv = BitVec::<LocalBits, usize>::with_capacity(payload.len() * 6);
+    let mut bv = BitVec::<usize, LocalBits>::with_capacity(payload.len() * 6);
     for c in payload.chars() {
         let mut ci = (c as u8) - 48;
         if ci > 40 {


### PR DESCRIPTION
Bitvec has been stabilized to 1.0
See: 
[https://github.com/bitvecto-rs/bitvec/blob/main/CHANGELOG.md#10](https://github.com/bitvecto-rs/bitvec/blob/main/CHANGELOG.md#10)