### PR TITLE
allow gnss structures to be serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ rust-version  = "1.56"
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.15", default-features = false }
-chrono = { version = "0.4.22", default-features = false }
+chrono = { version = "0.4.26", default-features = false, features = ["alloc"] }
 log = "0.4.17"
 hashbrown = "0.12.3"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 assert = "0.7.4"

--- a/src/gnss/alm.rs
+++ b/src/gnss/alm.rs
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use serde::Serialize;
+
 use super::*;
 
 /// ALM - GPS Almanac Data
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AlmData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/dbs.rs
+++ b/src/gnss/dbs.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// DBS - Depth Below Surface
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DbsData {
     /// Water depth below surface, meters
     pub depth_meters: Option<f64>,

--- a/src/gnss/dpt.rs
+++ b/src/gnss/dpt.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// DPT - Depth of Water
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DptData {
     /// Water depth relative to transducer, meters
     pub depth_relative_to_transducer: Option<f64>,

--- a/src/gnss/dtm.rs
+++ b/src/gnss/dtm.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// DTM - Datum being used
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct DtmData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/gga.rs
+++ b/src/gnss/gga.rs
@@ -17,12 +17,13 @@ limitations under the License.
 use super::*;
 
 /// GGA - time, position, and fix related data
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GgaData {
     /// Navigation system
     pub source: NavigationSystem,
 
     /// UTC of position fix
+    #[serde(with = "json_date_time_utc")]
     pub timestamp: Option<DateTime<Utc>>,
 
     /// Latitude in degrees
@@ -64,7 +65,7 @@ impl LatLon for GgaData {
 }
 
 /// GGA GPS quality indicator
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum GgaQualityIndicator {
     Invalid,                // 0
     GpsFix,                 // 1

--- a/src/gnss/gll.rs
+++ b/src/gnss/gll.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use super::*;
 
 /// GLL - geographic Position - Latitude/Longitude
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GllData {
     /// Navigation system
     pub source: NavigationSystem,
@@ -28,6 +28,7 @@ pub struct GllData {
     pub longitude: Option<f64>,
 
     /// UTC of position fix
+    #[serde(with = "json_date_time_utc")]
     pub timestamp: Option<DateTime<Utc>>,
 
     /// True = data valid, false = data invalid.

--- a/src/gnss/gsa.rs
+++ b/src/gnss/gsa.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use super::*;
 /// GSA - GNSS dilution of position (DOP) and active satellites
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GsaData {
     /// Navigation system
     pub source: NavigationSystem,
@@ -40,7 +40,7 @@ pub struct GsaData {
 }
 
 /// GSA position fix type
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum GsaFixMode {
     /// No fix.
     NotAvailable,

--- a/src/gnss/gsv.rs
+++ b/src/gnss/gsv.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use super::*;
 
 /// GSV - satellite information
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GsvData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/hdt.rs
+++ b/src/gnss/hdt.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// HDT - Heading, true
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct HdtData {
     /// Heading - true
     pub heading_true: Option<f64>,

--- a/src/gnss/mod.rs
+++ b/src/gnss/mod.rs
@@ -43,6 +43,7 @@ pub use gns::GnsData;
 pub use gsa::{GsaData, GsaFixMode};
 pub use gsv::GsvData;
 pub use rmc::RmcData;
+use serde::Serialize;
 pub use vtg::VtgData;
 pub use alm::AlmData;
 pub use dtm::DtmData;
@@ -60,7 +61,7 @@ pub use mwv::MwvData;
 // -------------------------------------------------------------------------------------------------
 
 /// Navigation system, identified with NMEA GNSS sentence prefix (e.g. $BDGGA)
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum NavigationSystem {
     /// Combination of several satellite systems
     Combination, // GNxxx
@@ -139,7 +140,7 @@ impl core::str::FromStr for NavigationSystem {
 
 // -------------------------------------------------------------------------------------------------
 /// VTG/GLL FAA mode (NMEA 2.3 standard has this information)
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum FaaMode {
     /// Autonomous mode (automatic 2D/3D)
     Autonomous,

--- a/src/gnss/mss.rs
+++ b/src/gnss/mss.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// MSS - Multiple Data ID
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct MssData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/mtw.rs
+++ b/src/gnss/mtw.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// MTW - Mean Temperature of Water
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct MtwData {
     /// Water temperature in degrees Celsius
     pub temperature: Option<f64>,

--- a/src/gnss/mwv.rs
+++ b/src/gnss/mwv.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// MWV - Wind speed and angle
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct MwvData {
     /// wind angle, 0 to 359 degrees
     pub wind_angle: Option<f64>,

--- a/src/gnss/rmc.rs
+++ b/src/gnss/rmc.rs
@@ -16,12 +16,13 @@ limitations under the License.
 use super::*;
 
 /// RMC - position, velocity, and time (Recommended Minimum sentence C)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RmcData {
     /// Navigation system
     pub source: NavigationSystem,
 
     /// Fix datetime based on HHMMSS and DDMMYY
+    #[serde(with = "json_date_time_utc")]
     pub timestamp: Option<DateTime<Utc>>,
 
     /// Status: true = active, false = void.

--- a/src/gnss/stn.rs
+++ b/src/gnss/stn.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// STN - MSK Receiver Signal
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct StnData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/vbw.rs
+++ b/src/gnss/vbw.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// VBW - Dual Ground/Water Speed
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct VbwData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/vhw.rs
+++ b/src/gnss/vhw.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::*;
 
 /// VHW - Water speed and heading
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct VhwData {
     /// Heading - true
     pub heading_true: Option<f64>,

--- a/src/gnss/vtg.rs
+++ b/src/gnss/vtg.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use super::*;
 
 /// VTG - track made good and speed over ground
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct VtgData {
     /// Navigation system
     pub source: NavigationSystem,

--- a/src/gnss/zda.rs
+++ b/src/gnss/zda.rs
@@ -17,15 +17,17 @@ limitations under the License.
 use super::*;
 
 /// ZDA - Time and date
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ZdaData {
     /// Navigation system
     pub source: NavigationSystem,
 
     /// UTC
+    #[serde(with = "json_date_time_utc")]
     pub timestamp_utc: Option<DateTime<Utc>>,
 
     /// Local time zone offset
+    #[serde(with = "json_fixed_offset")]
     pub timezone_local: Option<FixedOffset>,
 }
 

--- a/src/json_date_time_utc.rs
+++ b/src/json_date_time_utc.rs
@@ -1,0 +1,22 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<S: Serializer>(time: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error> {
+    match time {
+        Some(t) => t.to_rfc3339().serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<NaiveDateTime>, D::Error> {
+    let time: Option<&str> = Option::deserialize(deserializer)?;
+    
+    match time {
+        Some(t) => {
+            let dt = DateTime::parse_from_rfc3339(&t)
+                .map_err(D::Error::custom)?;
+            Ok(Some(dt.naive_utc()))
+        },
+        None => Ok(None),
+    }
+}

--- a/src/json_fixed_offset.rs
+++ b/src/json_fixed_offset.rs
@@ -1,0 +1,18 @@
+use chrono::{FixedOffset, offset::Offset};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<S: Serializer>(offset: &Option<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error> {
+    match offset {
+        Some(o) => o.fix().local_minus_utc().serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<FixedOffset>, D::Error> {
+    let offset_seconds: Option<i32> = Option::deserialize(deserializer)?;
+    
+    match offset_seconds {
+        Some(seconds) => Ok(Some(FixedOffset::east_opt(seconds).ok_or_else(|| D::Error::custom("Invalid offset"))?)),
+        None => Ok(None),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod ais;
 mod error;
 pub mod gnss;
 mod util;
+mod json_date_time_utc;
+mod json_fixed_offset;
 
 pub use error::ParseError;
 use util::*;


### PR DESCRIPTION
I highly doubt anybody wants this or that this is the right way to do this (especially the json_time bits)

However, it does "enable" the end user of this library to then convert the serial stream of NMEA packets into `json_diff` patches like this:

```rust
use std::io::{self, BufRead};
use std::time::Duration;
use nmea_parser::NmeaParser;
use nmea_parser::gnss::*;
use serde::Serialize;

#[derive(Debug, Serialize, Clone)]
struct ParsedNmeaData {
    gga_data: Option<GgaData>,
    rmc_data: Option<RmcData>,
    gsa_data: Option<GsaData>,
    gsv_data: Option<Vec<GsvData>>,
    vtg_data: Option<VtgData>,
    gll_data: Option<GllData>
}

fn main() {
    // NMEA parser
    let mut nmea_parser = NmeaParser::new();
    // serial port
    let path = "/dev/cu.usbmodem1301";
    let baud_rate = 9600;
    let mut port = serialport::new(path, baud_rate)
        .timeout(Duration::from_millis(10))
        .open()
        .unwrap();
    // line reader
    let mut reader = io::BufReader::new(&mut port);
    let mut buffer = String::new();
    // state
    let mut parsed_nmea_data = ParsedNmeaData {
        gga_data: None,
        rmc_data: None,
        gsa_data: None,
        gsv_data: None,
        vtg_data: None,
        gll_data: None
    };
    loop {
        let old_parsed_nmea_data = parsed_nmea_data.clone();
        match reader.read_line(&mut buffer) {
            Ok(_n) => {
                buffer = buffer.trim().to_string();
                if !buffer.is_empty() {
                    match nmea_parser.parse_sentence(&buffer) {
                        Ok(parsed_message) => {
                            match parsed_message {
                                nmea_parser::ParsedMessage::Incomplete => {
                                    /* nop */
                                },
                                nmea_parser::ParsedMessage::Gga(gga_data) => {
                                    parsed_nmea_data.gga_data.replace(gga_data);
                                },
                                nmea_parser::ParsedMessage::Rmc(rmc_data) => {
                                    parsed_nmea_data.rmc_data.replace(rmc_data);
                                },
                                nmea_parser::ParsedMessage::Gsa(gsa_data) => {
                                    parsed_nmea_data.gsa_data.replace(gsa_data);
                                }
                                nmea_parser::ParsedMessage::Gsv(gsv_data) => {
                                    parsed_nmea_data.gsv_data.replace(gsv_data);
                                },
                                nmea_parser::ParsedMessage::Vtg(vtg_data) => {
                                    parsed_nmea_data.vtg_data.replace(vtg_data);
                                },
                                nmea_parser::ParsedMessage::Gll(gll_data) => {
                                    parsed_nmea_data.gll_data.replace(gll_data);
                                },
                                _ => todo!(),
                            }
                        }
                        Err(parse_error) => eprintln!("{:?}", parse_error),
                    }
                    buffer.clear();
                }
            },
            Err(e) if e.kind() == io::ErrorKind::TimedOut => (),
            Err(e) => eprintln!("{:?}", e),
        }
        let patches = json_patch::diff(&serde_json::json!(old_parsed_nmea_data), &serde_json::json!(parsed_nmea_data));
        if patches.len() > 0 {
            println!("{}", serde_json::to_string(&patches).unwrap());
        }
    }
}
```